### PR TITLE
dupbenchtickpublish: Publish batches at regular intervals.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Go build image
 FROM golang:1.13.4-buster AS go_builder
-COPY . /go/src/streambench
-WORKDIR /go/src/streambench
-RUN go install --mod=readonly -v ./dupbenchpublisher ./dupbenchsubscriber && \
+COPY . streambench
+WORKDIR streambench
+RUN go install --mod=readonly -v ./dupbenchpublisher ./dupbenchsubscriber ./dupbenchtickpublish && \
   go build --race --mod=readonly -v -o /go/bin/dupbenchpublisher-race ./dupbenchpublisher && \
   go build --race --mod=readonly -v -o /go/bin/dupbenchsubscriber-race ./dupbenchsubscriber
 
@@ -28,4 +28,10 @@ USER nonroot
 FROM gcr.io/distroless/base-debian10 AS publisher
 COPY --from=go_builder /go/bin/dupbenchpublisher /
 ENTRYPOINT ["/dupbenchpublisher"]
+USER nonroot
+
+# Tick publisher
+FROM gcr.io/distroless/base-debian10 AS tickpublish
+COPY --from=go_builder /go/bin/dupbenchtickpublish /
+ENTRYPOINT ["/dupbenchtickpublish"]
 USER nonroot

--- a/circleci.sh
+++ b/circleci.sh
@@ -28,6 +28,7 @@ CHANGED=$(git status --porcelain --untracked-files=no)
 if [ -n "${CHANGED}" ]; then
     echo "ERROR files were changed:" > /dev/stderr
     echo "$CHANGED" > /dev/stderr
+    git diff --no-pager
     exit 10
 fi
 

--- a/circleci.sh
+++ b/circleci.sh
@@ -26,6 +26,7 @@ CHANGED=$(git status --porcelain --untracked-files=no)
 if [ -n "${CHANGED}" ]; then
     echo "ERROR files were changed:" > /dev/stderr
     echo "$CHANGED" > /dev/stderr
+    git diff -u > /dev/stderr
     exit 10
 fi
 

--- a/circleci.sh
+++ b/circleci.sh
@@ -28,7 +28,6 @@ CHANGED=$(git status --porcelain --untracked-files=no)
 if [ -n "${CHANGED}" ]; then
     echo "ERROR files were changed:" > /dev/stderr
     echo "$CHANGED" > /dev/stderr
-    git diff --no-pager
     exit 10
 fi
 

--- a/circleci.sh
+++ b/circleci.sh
@@ -17,7 +17,7 @@ go vet -mod=readonly ./...
 
 # cd /tmp to not change go.mod/go.sum for golint TODO: Use tools.go:
 # https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
-cd /tmp && go get golang.org/x/lint/golint
+(cd /tmp && go get golang.org/x/lint/golint)
 golint --set_exit_status ./...
 
 diff -u <(echo -n) <(gofmt -d .)

--- a/circleci.sh
+++ b/circleci.sh
@@ -15,7 +15,9 @@ go test -mod=readonly -race ./...
 # go test only checks some vet warnings; check all
 go vet -mod=readonly ./...
 
-go get -mod=readonly golang.org/x/lint/golint
+# cd /tmp to not change go.mod/go.sum for golint TODO: Use tools.go:
+# https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+cd /tmp go get golang.org/x/lint/golint
 golint --set_exit_status ./...
 
 diff -u <(echo -n) <(gofmt -d .)
@@ -26,7 +28,6 @@ CHANGED=$(git status --porcelain --untracked-files=no)
 if [ -n "${CHANGED}" ]; then
     echo "ERROR files were changed:" > /dev/stderr
     echo "$CHANGED" > /dev/stderr
-    git diff -u > /dev/stderr
     exit 10
 fi
 

--- a/circleci.sh
+++ b/circleci.sh
@@ -17,7 +17,7 @@ go vet -mod=readonly ./...
 
 # cd /tmp to not change go.mod/go.sum for golint TODO: Use tools.go:
 # https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
-cd /tmp go get golang.org/x/lint/golint
+cd /tmp && go get golang.org/x/lint/golint
 golint --set_exit_status ./...
 
 diff -u <(echo -n) <(gofmt -d .)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,8 @@
 # builds both the publisher and subscriber
 steps:
 - name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--target=tickpublish', '--tag=gcr.io/$PROJECT_ID/dupbenchtickpublish', '.']
+- name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--target=publisher', '--tag=gcr.io/$PROJECT_ID/dupbenchpublisher', '.']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--target=publisher-race', '--tag=gcr.io/$PROJECT_ID/dupbenchpublisher-race', '.']
@@ -9,6 +11,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--target=subscriber-race', '--tag=gcr.io/$PROJECT_ID/dupbenchsubscriber-race', '.']
 images:
+- 'gcr.io/$PROJECT_ID/dupbenchtickpublish'
 - 'gcr.io/$PROJECT_ID/dupbenchpublisher'
 - 'gcr.io/$PROJECT_ID/dupbenchpublisher-race'
 - 'gcr.io/$PROJECT_ID/dupbenchsubscriber'

--- a/dupbench/dupbench.go
+++ b/dupbench/dupbench.go
@@ -1,0 +1,127 @@
+package dupbench
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"flag"
+	"log"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/evanj/streambench/messages"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/timestamp"
+)
+
+// 16 = 128 bits which should make collisions "impossible"
+const goroutineIDLength = 16
+
+// pubsub has a maximum of 1000 messages per publish request. Hopefully this is enough messages
+// to "fill" the pipeline and keep the publishing busy
+const publishWaitAfterMessages = 2000
+
+func setTimestampNow(ts *timestamp.Timestamp) {
+	// stupidly over-optimized to avoid allocations (probably unnecessary)
+	t := time.Now()
+	ts.Seconds = t.Unix()
+	ts.Nanos = int32(t.Nanosecond())
+}
+
+func waitForPublish(ctx context.Context, results []*pubsub.PublishResult) {
+	for _, r := range results {
+		_, err := r.Get(ctx)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func (c *Client) publisherGoroutine(wg *sync.WaitGroup, idString string) {
+	defer wg.Done()
+
+	ctx := context.Background()
+	msg := &messages.DuplicateTest{
+		GoroutineId: idString,
+		Created:     ptypes.TimestampNow(),
+	}
+
+	results := []*pubsub.PublishResult{}
+	for i := 0; i < c.numMessages; i++ {
+		msg.Sequence = int64(i)
+		setTimestampNow(msg.Created)
+
+		// must create new pubsub.Message/bytes since Publish takes a reference
+		msgBytes, err := proto.Marshal(msg)
+		if err != nil {
+			panic(err)
+		}
+
+		psMsg := &pubsub.Message{Data: msgBytes}
+		results = append(results, c.topic.Publish(ctx, psMsg))
+		if len(results) >= publishWaitAfterMessages {
+			waitForPublish(ctx, results)
+			results = results[:0]
+		}
+	}
+	waitForPublish(ctx, results)
+	log.Printf("goroutine %s exiting", idString)
+}
+
+type Client struct {
+	goroutines   int
+	numMessages  int
+	pubsubClient *pubsub.Client
+	topic        *pubsub.Topic
+}
+
+func (c *Client) PublishBatch() error {
+	start := time.Now()
+	log.Printf("starting batch ...")
+	wg := &sync.WaitGroup{}
+	for i := 0; i < c.goroutines; i++ {
+		idBytes := make([]byte, goroutineIDLength)
+		_, err := rand.Read(idBytes)
+		if err != nil {
+			panic(err)
+		}
+		idString := hex.EncodeToString(idBytes)
+
+		wg.Add(1)
+		go c.publisherGoroutine(wg, idString)
+	}
+	wg.Wait()
+	end := time.Now()
+
+	duration := end.Sub(start)
+	totalMessages := c.goroutines * c.numMessages
+	rate := float64(totalMessages) / duration.Seconds()
+	log.Printf("published %d total messages in %s ; %.1f msgs/sec",
+		totalMessages, duration.String(), rate)
+	return nil
+}
+
+// ParseClient parses command line arguments and returns a configured client.
+func ParseClient() (*Client, error) {
+	projectID := flag.String("projectID", "", "Google Cloud Project ID (empty = default)")
+	topicID := flag.String("topicID", "dupbench", "Pub/Sub topic ID to publish to")
+	goroutines := flag.Int("goroutines", 1, "number of goroutines to use to publish at a time")
+	numMessages := flag.Int("numMessages", 1000, "numMessages each goroutine will publish in a batch")
+	flag.Parse()
+
+	ctx := context.Background()
+	pubsubClient, err := pubsub.NewClient(ctx, *projectID)
+	if err != nil {
+		return nil, err
+	}
+	topic := pubsubClient.Topic(*topicID)
+
+	return &Client{*goroutines, *numMessages, pubsubClient, topic}, nil
+}
+
+func (c *Client) Close() error {
+	c.topic.Stop()
+	return c.pubsubClient.Close()
+}

--- a/dupbench/dupbench.go
+++ b/dupbench/dupbench.go
@@ -70,6 +70,7 @@ func (c *Client) publisherGoroutine(wg *sync.WaitGroup, idString string) {
 	log.Printf("goroutine %s exiting", idString)
 }
 
+// Client publishes batches of messages to Pub/Sub.
 type Client struct {
 	goroutines   int
 	numMessages  int
@@ -77,6 +78,7 @@ type Client struct {
 	topic        *pubsub.Topic
 }
 
+// PublishBatch publishes one batch of messages.
 func (c *Client) PublishBatch() error {
 	start := time.Now()
 	log.Printf("starting batch ...")
@@ -121,6 +123,7 @@ func ParseClient() (*Client, error) {
 	return &Client{*goroutines, *numMessages, pubsubClient, topic}, nil
 }
 
+// Close flushes messages from the topic and stops the pub/sub client.
 func (c *Client) Close() error {
 	c.topic.Stop()
 	return c.pubsubClient.Close()

--- a/dupbenchsetup/dupbenchsetup.go
+++ b/dupbenchsetup/dupbenchsetup.go
@@ -73,7 +73,8 @@ type cliArgs struct {
 func setUp(args cliArgs) error {
 	log.Println("creating pubsub topic/subscription")
 	mustGcloud("--project="+args.projectID, "pubsub", "topics", "create", args.topicID)
-	mustGcloud("--project="+args.projectID, "pubsub", "subscriptions", "create", "--topic="+args.topicID, args.subscriptionID)
+	mustGcloud("--project="+args.projectID, "pubsub", "subscriptions", "create", "--ack-deadline=120",
+		"--topic="+args.topicID, args.subscriptionID)
 
 	log.Println("creating bigquery table")
 	mustBQ("--project="+args.projectID, "mk", args.datasetID)
@@ -126,7 +127,8 @@ func tearDown(args cliArgs) error {
 	log.Println("deleting bigquery dataset")
 	mustBQ("--project="+args.projectID, "rm", "-r", "-f", args.datasetID)
 
-	patterns := []string{"gcr.io/%s/dupbenchpublisher", "gcr.io/%s/dupbenchsubscriber"}
+	patterns := []string{"gcr.io/%s/dupbenchpublisher", "gcr.io/%s/dupbenchtickpublish",
+		"gcr.io/%s/dupbenchsubscriber"}
 	for _, pattern := range patterns {
 		containerURL := fmt.Sprintf(pattern, args.projectID)
 		err := deleteAllImages(args.projectID, containerURL)

--- a/dupbenchtickpublish/dupbenchtickpublish.go
+++ b/dupbenchtickpublish/dupbenchtickpublish.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"time"
+
+	"github.com/evanj/streambench/dupbench"
+)
+
+func main() {
+	publishInterval := flag.Duration("interval", 2*time.Minute, "interval to publish a new batch")
+	client, err := dupbench.ParseClient()
+	if err != nil {
+		panic(err)
+	}
+
+	now := time.Now().UTC()
+	nextWakeUp := now.Truncate(*publishInterval).Add(*publishInterval)
+	log.Printf("now:%s starting at %s ...",
+		now.Format(time.RFC3339), nextWakeUp.Format(time.RFC3339))
+	for {
+		time.Sleep(nextWakeUp.Sub(time.Now()))
+		nextWakeUp = nextWakeUp.Add(*publishInterval)
+
+		err = client.PublishBatch()
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// technically probably does not need to be closed since we are exiting
+	err = client.Close()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/dupbenchtickpublish/dupbenchtickpublish.go
+++ b/dupbenchtickpublish/dupbenchtickpublish.go
@@ -28,10 +28,4 @@ func main() {
 			panic(err)
 		}
 	}
-
-	// technically probably does not need to be closed since we are exiting
-	err = client.Close()
-	if err != nil {
-		panic(err)
-	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	cloud.google.com/go/bigquery v1.0.1
 	cloud.google.com/go/pubsub v1.1.0
 	github.com/golang/protobuf v1.3.2
-	golang.org/x/tools v0.0.0-20191124021906-f5828fc9a103 // indirect
 	google.golang.org/api v0.14.0
 	google.golang.org/genproto v0.0.0-20191115221424-83cc0476cb11
 	google.golang.org/grpc v1.25.1

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,6 @@ golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2 h1:EtTFh6h4SAKemS+CURDMTDIANuduG5zKEXShyy18bGA=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20191124021906-f5828fc9a103 h1:etSZZCMgaL7Z8Zy3W70DnOZ9RNPujuF/2ueQnnM+Uoc=
-golang.org/x/tools v0.0.0-20191124021906-f5828fc9a103/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=


### PR DESCRIPTION
This will probably make it easier to understand duplication than
pushing very large batches.